### PR TITLE
final (?) fix for locale problem (RT #41285)

### DIFF
--- a/t/exec.t
+++ b/t/exec.t
@@ -31,8 +31,12 @@ require "filter-util.pl" ;
 use vars qw( $Inc $Perl $script ) ;
 
 $script = '';
-if (exists $ENV{LANG} and $ENV{LANG} !~ /^C|en/) { # CPAN #41285
-  $script = q($ENV{LANG}='C'; $ENV{LC_ALL}='C';);
+if (eval {
+    require POSIX;
+    my $val = POSIX::setlocale(&POSIX::LC_CTYPE);
+    $val !~ m{^(C|en)}
+}) { # CPAN #41285
+  $script = q(BEGIN { $ENV{LANG}=$ENV{LC_ALL}=$ENV{LC_CTYPE}='C'; });
 }
 
 $script .= <<'EOF' ;

--- a/t/sh.t
+++ b/t/sh.t
@@ -31,8 +31,12 @@ require "filter-util.pl" ;
 use vars qw( $Inc $Perl $script ) ;
 
 $script = '';
-if (exists $ENV{LANG} and $ENV{LANG} !~ /^C|en/) { # CPAN #41285
-  $script = q($ENV{LANG}='C'; $ENV{LC_ALL}='C';);
+if (eval {
+    require POSIX;
+    my $val = POSIX::setlocale(&POSIX::LC_CTYPE);
+    $val !~ m{^(C|en)}
+}) { # CPAN #41285
+  $script = q(BEGIN { $ENV{LANG}=$ENV{LC_ALL}=$ENV{LC_CTYPE}='C'; });
 }
 
 $script .= <<"EOF" ;


### PR DESCRIPTION
Instead of testing the value of the env variables, use
POSIX::setlocale to get the effective value of the LC_CTYPE
locale (the only one effecting tr operation).

For the workaround on top of the script, add also LC_CTYPE
to the list of env variables explicitely set to C.

Also, setting the env variables must happen in a BEGIN{}
block, otherwise things are too late.
