### PR TITLE
Remove DynaLoader, "use vars" and lazy load Carp

### DIFF
--- a/Call/Call.pm
+++ b/Call/Call.pm
@@ -9,14 +9,14 @@
  
 package Filter::Util::Call ;
 
-require 5.005 ;
-require DynaLoader;
+require 5.006;
 require Exporter;
 
+use XSLoader ();
 use strict;
 use warnings;
 
-our @ISA = qw(Exporter DynaLoader);
+our @ISA = qw(Exporter);
 our @EXPORT = qw( filter_add filter_del filter_read filter_read_exact) ;
 our $VERSION = "1.57" ;
 our $XS_VERSION = $VERSION;
@@ -60,7 +60,7 @@ sub filter_add($)
     Filter::Util::Call::real_import($obj, (caller)[0], $coderef) ;
 }
 
-bootstrap Filter::Util::Call ;
+XSLoader::load( 'Filter::Util::Call' );
 
 1;
 __END__

--- a/Call/Call.pm
+++ b/Call/Call.pm
@@ -15,12 +15,11 @@ require Exporter;
 use Carp ;
 use strict;
 use warnings;
-use vars qw($VERSION $XS_VERSION @ISA @EXPORT) ;
 
-@ISA = qw(Exporter DynaLoader);
-@EXPORT = qw( filter_add filter_del filter_read filter_read_exact) ;
-$VERSION = "1.57" ;
-$XS_VERSION = $VERSION;
+our @ISA = qw(Exporter DynaLoader);
+our @EXPORT = qw( filter_add filter_del filter_read filter_read_exact) ;
+our $VERSION = "1.57" ;
+our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
 sub filter_read_exact($)

--- a/Call/Call.pm
+++ b/Call/Call.pm
@@ -12,7 +12,7 @@ package Filter::Util::Call ;
 require 5.005 ;
 require DynaLoader;
 require Exporter;
-use Carp ;
+
 use strict;
 use warnings;
 
@@ -28,8 +28,10 @@ sub filter_read_exact($)
     my ($left)   = $size ;
     my ($status) ;
 
-    croak ("filter_read_exact: size parameter must be > 0")
-	unless $size > 0 ;
+    unless ( $size > 0 ) {
+        require Carp;
+        Carp::croak("filter_read_exact: size parameter must be > 0");
+    }
 
     # try to read a block which is exactly $size bytes long
     while ($left and ($status = filter_read($left)) > 0) {


### PR DESCRIPTION
Three different changes in this pull request, each of them having their own commit.

* Switch Filter::Util::Call to XSLoader
* Lazy load Carp only when require 
* Replace "use vars" by our

Let me know if you prefer individual pull request for them.