### PR TITLE
Testsuite is using FindBin path to load filter-util.pl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ inline.h.gcov
 */*.gcda
 */*.gcno
 /cover_db
+nytprof.out

--- a/t/call.t
+++ b/t/call.t
@@ -1,4 +1,5 @@
 use Config;
+
 BEGIN {
     if ($ENV{PERL_CORE}) {
         if ($Config{'extensions'} !~ m{\bFilter/Util/Call\b}) {
@@ -6,12 +7,15 @@ BEGIN {
             exit 0;
         }
     }
-    unshift @INC, 't';
-    require 'filter-util.pl';
 }
 
 use strict;
 use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
+require 'filter-util.pl';
 
 use vars qw($Inc $Perl);
 

--- a/t/cpp.t
+++ b/t/cpp.t
@@ -3,10 +3,13 @@ use strict;
 use warnings;
 use Config;
 
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 BEGIN {
     my $cpp;
     my $sep;
-    unshift @INC, 't';
+
     if ($^O eq 'MSWin32') {
         $cpp = 'cpp.exe' ;
         $sep = ';';

--- a/t/decrypt.t
+++ b/t/decrypt.t
@@ -1,8 +1,12 @@
 
 use strict;
 use warnings;
-BEGIN { unshift @INC, 't'; }
-require "filter-util.pl" ;
+
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
+require "filter-util.pl";
+
 use Config;
 use Cwd ;
 my $here = getcwd ;

--- a/t/exec.t
+++ b/t/exec.t
@@ -3,8 +3,10 @@ use strict;
 use warnings;
 use Config;
 
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 BEGIN {
-    unshift @INC, 't';
     my $foundTR = 0 ;
     if ($^O eq 'MSWin32') {
         # Check if tr is installed

--- a/t/m4.t
+++ b/t/m4.t
@@ -4,10 +4,13 @@ use strict;
 use warnings;
 use Config;
 
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 BEGIN {
     my $m4;
     my $sep;
-    unshift @INC, 't';
+
     if ($^O eq 'MSWin32') {
         $m4 = 'm4.exe';
         $sep = ';';
@@ -36,7 +39,6 @@ BEGIN {
         }
     }
 }
-
 
 use vars qw($Inc $Perl);
 

--- a/t/order.t
+++ b/t/order.t
@@ -12,7 +12,10 @@ if ($] < 5.006) {
 
 use strict;
 use warnings;
-BEGIN { unshift @INC, 't'; }
+
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 require "filter-util.pl" ;
 
 use vars qw( $Inc $Perl) ;

--- a/t/rt_54452-rebless.t
+++ b/t/rt_54452-rebless.t
@@ -8,7 +8,9 @@ if ($] < 5.004_55) {
 
 use strict;
 use warnings;
-BEGIN { unshift @INC, 't'; }
+
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
 
 require "filter-util.pl" ;
 

--- a/t/sh.t
+++ b/t/sh.t
@@ -3,9 +3,11 @@ use strict;
 use warnings;
 use Config;
 
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 BEGIN
 {
-    unshift @INC, 't';
     my $foundTR = 0 ;
     if ($^O eq 'MSWin32') {
         # Check if tr is installed

--- a/t/tee.t
+++ b/t/tee.t
@@ -1,7 +1,10 @@
 #! perl
 use strict;
 use warnings;
-BEGIN { unshift @INC, 't'; }
+
+use FindBin;
+use lib "$FindBin::Bin"; # required to load filter-util.pl
+
 require "filter-util.pl" ;
 
 use vars qw( $Inc $Perl $tee1) ;


### PR DESCRIPTION
Instead of adding a relative 't' directory to @INC
use the full path using FindBin which makes it possible
to run the test from any locations.

This would allow us to remove the 'cpan/Filter-Util-Call' exception
from t/TEST in blead.