### PR TITLE
Set path correctly for PERL_CORE

### DIFF
--- a/t/call.t
+++ b/t/call.t
@@ -6,6 +6,8 @@ BEGIN {
             print "1..0 # Skip: Filter::Util::Call was not built\n";
             exit 0;
         }
+        require Cwd;
+        unshift @INC, Cwd::cwd();
     }
 }
 

--- a/t/rt_54452-rebless.t
+++ b/t/rt_54452-rebless.t
@@ -6,6 +6,13 @@ if ($] < 5.004_55) {
   exit 0;
 }
 
+BEGIN {
+    if ($ENV{PERL_CORE}) {
+        require Cwd;
+        unshift @INC, Cwd::cwd();
+    }
+}
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
One of the major changes introduced in perl-5.28 in 2018 was a security fix which caused directory `.` to no longer be automatically included in `@INC`.  Prior to that production release, we had to make certain workarounds in an important component of the Perl 5 testing infrastructure, `t/TEST`, to accommodate three CPAN distributions which are shipped with the Perl 5 core distribution.

The Filter distribution was one of those three.  We would like to be able to remove the workaround from `t/TEST`.  To that end, I am submitting this pull request which includes revisions to the `BEGIN` block in two files and which I have tested successfully both in core and in a git checkout.

If these changes are satisfactory, we would appreciate a new CPAN release of Filter so that we can then synch it into Perl 5 blead.

Thank you very much.
Jim Keenan